### PR TITLE
Sealing classes

### DIFF
--- a/src/PSTree/PSTreeCache.cs
+++ b/src/PSTree/PSTreeCache.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace PSTree;
 
-internal class PSTreeCache
+internal sealed class PSTreeCache
 {
     private readonly List<PSTreeFileSystemInfo> _items;
 

--- a/src/PSTree/PSTreeIndexer.cs
+++ b/src/PSTree/PSTreeIndexer.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace PSTree;
 
-internal class PSTreeIndexer
+internal sealed class PSTreeIndexer
 {
     private readonly Dictionary<string, PSTreeDirectory> _indexer = new();
 

--- a/src/PSTree/PathExtensions.cs
+++ b/src/PSTree/PathExtensions.cs
@@ -43,7 +43,6 @@ internal static class PathExtensions
 
                     cmdlet.WriteError(ExceptionHelpers
                         .InvalidProviderError(path, provider));
-
                     continue;
                 }
 
@@ -95,7 +94,8 @@ internal static class PathExtensions
         bool isLiteral,
         PSCmdlet cmdlet,
         bool throwOnInvalidPath = false,
-        bool throwOnInvalidProvider = false) => NormalizePath(
+        bool throwOnInvalidProvider = false) =>
+        NormalizePath(
             new[] { path },
             isLiteral,
             cmdlet,


### PR DESCRIPTION
`PSTreeCache` and `PSTreeIndexer` internal classes have been sealed following the recommendations from https://github.com/dotnet/runtime/issues/49944