### PR TITLE
Add Item count properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # CHANGELOG
 
+- __09/03/2024__
+  - Makes `.Depth` property public for `PSTreeFileSystemInfo` instances.
+  - Makes `.GetParents()` method private, absolutely no reason to have it public.
+  - Added property `ItemCount` and `TotalItemCount` to `PSTreeDirectory` instances, requested in [__Issue #34__][2].
+
+    ```powershell
+    PS ..\PSTree> pstree -Recurse -Force -Directory | Select-Object Hierarchy, Depth, ItemCount, TotalItemCount -First 15
+
+    Hierarchy                  Depth ItemCount TotalItemCount
+    ---------                  ----- --------- --------------
+    PSTree                         0        15           1476
+    ├── .git                       1        13           1078
+    │   ├── hooks                  2        13             13
+    │   ├── info                   2         1              1
+    │   ├── logs                   2         2             24
+    │   │   └── refs               3         2             22
+    │   │       ├── heads          4         9              9
+    │   │       └── remotes        4         1             11
+    │   │           └── origin     5        10             10
+    │   ├── objects                2       244            995
+    │   │   ├── 00                 3         3              3
+    │   │   ├── 01                 3         2              2
+    │   │   ├── 02                 3         3              3
+    │   │   ├── 03                 3         4              4
+    │   │   ├── 04                 3         2              2
+
+    PS ..\PSTree> (Get-ChildItem -Force).Count
+    15
+    PS ..\PSTree> (Get-ChildItem -Force -Recurse).Count
+    1476
+    PS ..\PSTree> (Get-ChildItem .git -Force -Recurse).Count
+    1078
+    PS ..\PSTree> (Get-ChildItem .git -Force).Count
+    13
+    PS ..\PSTree>
+    ```
+
 - __08/29/2024__
   - Added method `.GetUnderlyingObject()`. Outputs the underlying `FileSystemInfo` instance.
   - Fixes [__Issue #9: Sort by ascending values__][1]:
@@ -233,3 +270,4 @@ d----     └── Format                     1.83 Kb
 [18]: https://github.com/jborean93/
 [19]: /docs/en-US/Get-PSTree.md
 [20]: https://www.powershellgallery.com/
+[2]: https://github.com/santisq/PSTree/issues/34

--- a/module/PSTree.psd1
+++ b/module/PSTree.psd1
@@ -11,7 +11,7 @@
     RootModule = 'bin/netstandard2.0/PSTree.dll'
 
     # Version number of this module.
-    ModuleVersion = '2.1.17'
+    ModuleVersion = '2.1.18'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/PSTree/Commands/GetPSTreeCommand.cs
+++ b/src/PSTree/Commands/GetPSTreeCommand.cs
@@ -143,18 +143,17 @@ public sealed partial class GetPSTreeCommand : PSCmdlet
 
         while (_stack.Count > 0)
         {
-            IOrderedEnumerable<FileSystemInfo> enumerator;
             PSTreeDirectory next = _stack.Pop();
             int level = next.Depth + 1;
             long size = 0;
+            int childCount = 0;
 
             try
             {
-                enumerator = next.GetSortedEnumerable(_comparer);
                 bool keepProcessing = level <= Depth;
-
-                foreach (FileSystemInfo item in enumerator)
+                foreach (FileSystemInfo item in next.GetSortedEnumerable(_comparer))
                 {
+                    childCount++;
                     if (!Force.IsPresent && item.IsHidden())
                     {
                         continue;
@@ -190,10 +189,11 @@ public sealed partial class GetPSTreeCommand : PSCmdlet
                 }
 
                 next.Length = size;
+                _indexer.IndexItemCount(next, childCount);
 
                 if (RecursiveSize.IsPresent)
                 {
-                    _indexer.Index(next, size);
+                    _indexer.IndexLength(next, size);
                 }
 
                 if (next.Depth <= Depth)

--- a/src/PSTree/Commands/GetPSTreeCommand.cs
+++ b/src/PSTree/Commands/GetPSTreeCommand.cs
@@ -9,7 +9,7 @@ namespace PSTree.Commands;
 [Cmdlet(VerbsCommon.Get, "PSTree", DefaultParameterSetName = "Path")]
 [OutputType(typeof(PSTreeDirectory), typeof(PSTreeFile))]
 [Alias("pstree")]
-public sealed partial class GetPSTreeCommand : PSCmdlet
+public sealed class GetPSTreeCommand : PSCmdlet
 {
     private bool _isLiteral;
 

--- a/src/PSTree/Internal/_FormattingInternals.cs
+++ b/src/PSTree/Internal/_FormattingInternals.cs
@@ -28,8 +28,7 @@ public static class _FormattingInternals
         string.Format(CultureInfo.CurrentCulture, "{0,10:d} {0,8:t}", date);
 
     [Hidden, EditorBrowsable(EditorBrowsableState.Never)]
-    public static string GetSource(PSTreeFileSystemInfo item) =>
-        item.Source;
+    public static string GetSource(PSTreeFileSystemInfo item) => item.Source;
 
     [Hidden, EditorBrowsable(EditorBrowsableState.Never)]
     public static string GetFormattedLength(long length)

--- a/src/PSTree/PSTreeDirectory.cs
+++ b/src/PSTree/PSTreeDirectory.cs
@@ -6,7 +6,15 @@ namespace PSTree;
 
 public sealed class PSTreeDirectory : PSTreeFileSystemInfo<DirectoryInfo>
 {
+    private string[]? _parents;
+
     public DirectoryInfo Parent => Instance.Parent;
+
+    public int ItemCount { get; internal set; }
+
+    public int RecursiveItemCount { get; internal set; }
+
+    internal string[] Parents { get => _parents ??= GetParents(); }
 
     internal PSTreeDirectory(DirectoryInfo directoryInfo, int depth, string source) :
         base(directoryInfo, depth, source)
@@ -25,15 +33,18 @@ public sealed class PSTreeDirectory : PSTreeFileSystemInfo<DirectoryInfo>
     public IEnumerable<FileSystemInfo> EnumerateFileSystemInfos() =>
         Instance.EnumerateFileSystemInfos();
 
-    public IEnumerable<string> GetParents()
+    public string[] GetParents()
     {
         int index = -1;
         string path = Instance.FullName;
+        List<string> parents = [];
 
         while ((index = path.IndexOf(Path.DirectorySeparatorChar, index + 1)) != -1)
         {
-            yield return path.Substring(0, index);
+            parents.Add(path.Substring(0, index));
         }
+
+        return [.. parents];
     }
 
     internal IOrderedEnumerable<FileSystemInfo> GetSortedEnumerable(PSTreeComparer comparer) =>

--- a/src/PSTree/PSTreeDirectory.cs
+++ b/src/PSTree/PSTreeDirectory.cs
@@ -8,13 +8,13 @@ public sealed class PSTreeDirectory : PSTreeFileSystemInfo<DirectoryInfo>
 {
     private string[]? _parents;
 
+    internal string[] Parents { get => _parents ??= GetParents(FullName); }
+
     public DirectoryInfo Parent => Instance.Parent;
 
     public int ItemCount { get; internal set; }
 
-    public int RecursiveItemCount { get; internal set; }
-
-    internal string[] Parents { get => _parents ??= GetParents(); }
+    public int TotalItemCount { get; internal set; }
 
     internal PSTreeDirectory(DirectoryInfo directoryInfo, int depth, string source) :
         base(directoryInfo, depth, source)
@@ -33,10 +33,9 @@ public sealed class PSTreeDirectory : PSTreeFileSystemInfo<DirectoryInfo>
     public IEnumerable<FileSystemInfo> EnumerateFileSystemInfos() =>
         Instance.EnumerateFileSystemInfos();
 
-    public string[] GetParents()
+    private static string[] GetParents(string path)
     {
         int index = -1;
-        string path = Instance.FullName;
         List<string> parents = [];
 
         while ((index = path.IndexOf(Path.DirectorySeparatorChar, index + 1)) != -1)

--- a/src/PSTree/PSTreeFileSystemInfo.cs
+++ b/src/PSTree/PSTreeFileSystemInfo.cs
@@ -4,7 +4,7 @@ public abstract class PSTreeFileSystemInfo(string hierarchy, string source)
 {
     internal string Source { get; set; } = source;
 
-    public int Depth { get; set; }
+    public int Depth { get; protected set; }
 
     public string Hierarchy { get; internal set; } = hierarchy;
 

--- a/src/PSTree/PSTreeFileSystemInfo.cs
+++ b/src/PSTree/PSTreeFileSystemInfo.cs
@@ -4,7 +4,7 @@ public abstract class PSTreeFileSystemInfo(string hierarchy, string source)
 {
     internal string Source { get; set; } = source;
 
-    internal int Depth { get; set; }
+    public int Depth { get; set; }
 
     public string Hierarchy { get; internal set; } = hierarchy;
 

--- a/src/PSTree/PSTreeIndexer.cs
+++ b/src/PSTree/PSTreeIndexer.cs
@@ -7,15 +7,30 @@ internal sealed class PSTreeIndexer
 {
     private readonly Dictionary<string, PSTreeDirectory> _indexer = [];
 
-    internal void Index(PSTreeDirectory directory, long length)
+    internal void IndexLength(PSTreeDirectory directory, long length)
     {
         _indexer[directory.FullName.TrimEnd(Path.DirectorySeparatorChar)] = directory;
 
-        foreach (string parent in directory.GetParents())
+        foreach (string parent in directory.Parents)
         {
-            if (_indexer.ContainsKey(parent))
+            if (_indexer.TryGetValue(parent, out PSTreeDirectory paretDir))
             {
-                _indexer[parent].Length += length;
+                paretDir.Length += length;
+            }
+        }
+    }
+
+    internal void IndexItemCount(PSTreeDirectory directory, int count)
+    {
+        directory.ItemCount = count;
+        directory.RecursiveItemCount = count;
+        _indexer[directory.FullName.TrimEnd(Path.DirectorySeparatorChar)] = directory;
+
+        foreach (string parent in directory.Parents)
+        {
+            if (_indexer.TryGetValue(parent, out PSTreeDirectory parentDir))
+            {
+                parentDir.RecursiveItemCount += count;
             }
         }
     }

--- a/src/PSTree/PSTreeIndexer.cs
+++ b/src/PSTree/PSTreeIndexer.cs
@@ -23,14 +23,14 @@ internal sealed class PSTreeIndexer
     internal void IndexItemCount(PSTreeDirectory directory, int count)
     {
         directory.ItemCount = count;
-        directory.RecursiveItemCount = count;
+        directory.TotalItemCount = count;
         _indexer[directory.FullName.TrimEnd(Path.DirectorySeparatorChar)] = directory;
 
         foreach (string parent in directory.Parents)
         {
             if (_indexer.TryGetValue(parent, out PSTreeDirectory parentDir))
             {
-                parentDir.RecursiveItemCount += count;
+                parentDir.TotalItemCount += count;
             }
         }
     }

--- a/tests/GetPSTreeCommand.tests.ps1
+++ b/tests/GetPSTreeCommand.tests.ps1
@@ -95,19 +95,14 @@ Describe 'Get-PSTree' {
             Should -BeIn ([PSTree.PSTreeFile], [PSTree.PSTreeDirectory])
     }
 
-    It 'Excludes PSTressFile instances with -Directory' {
+    It 'Excludes PSTreeFile instances with -Directory' {
         Get-PSTree -LiteralPath $testPath -Directory |
             Should -BeOfType ([PSTree.PSTreeDirectory])
     }
 
     It 'Controls recursion with -Depth parameter' {
-        $method = [PSTree.PSTreeFileSystemInfo].GetProperty(
-            'Depth',
-            [System.Reflection.BindingFlags] 'NonPublic, Instance')
-
         $tree = Get-PSTree $testPath -Depth 1
-
-        $tree | ForEach-Object { $method.GetValue($_) } |
+        $tree | ForEach-Object Depth |
             Should -Not -BeGreaterThan 2
 
         $ref = (Get-ChildItem $testPath -Directory | Get-ChildItem).FullName

--- a/tests/PSTreeDirectory.tests.ps1
+++ b/tests/PSTreeDirectory.tests.ps1
@@ -23,11 +23,13 @@ Describe 'PSTreeDirectory' {
             Should -BeIn ([System.IO.FileInfo], [System.IO.DirectoryInfo])
     }
 
-    It 'Can enumerate its parent directories with .GetParents()' {
-        $treedir = $testPath | Get-PSTree -Depth 0
-        $parent = $treedir.Parent
-        $parent | Should -BeOfType ([System.IO.DirectoryInfo])
-        $paths = $parent.FullName.Split([System.IO.Path]::DirectorySeparatorChar)
-        $treedir.GetParents() | Should -HaveCount $paths.Count
+    It 'ItemCount gets the count of direct childs' {
+        $childCount = @(Get-ChildItem -Force $testPath).Count
+        (Get-PSTree $testPath -Depth 1 -Force)[0].ItemCount | Should -BeExactly $childCount
+    }
+
+    It 'TotalItemCount gets the recursive count of childs' {
+        $childCount = @(Get-ChildItem -Force $testPath -Recurse).Count
+        (Get-PSTree $testPath -Recurse -Force)[0].TotalItemCount | Should -BeExactly $childCount
     }
 }

--- a/tests/PSTreeDirectory.tests.ps1
+++ b/tests/PSTreeDirectory.tests.ps1
@@ -23,6 +23,10 @@ Describe 'PSTreeDirectory' {
             Should -BeIn ([System.IO.FileInfo], [System.IO.DirectoryInfo])
     }
 
+    It '.Parent property gets the PSTreeDirectory Parent DirectoryInfo instance' {
+        (Get-PSTree $testPath -Depth 0).Parent | Should -BeOfType ([System.IO.DirectoryInfo])
+    }
+
     It 'ItemCount gets the count of direct childs' {
         $childCount = @(Get-ChildItem -Force $testPath).Count
         (Get-PSTree $testPath -Depth 1 -Force)[0].ItemCount | Should -BeExactly $childCount


### PR DESCRIPTION
This PR makes `Depth` property public and adds two properties to `PSTreeDirectory` having child item and total child item count. Addresses #34.