### PR TITLE
`Get-PSTreeRegistry` no longer ignores `(Default)` (empty Values)

### DIFF
--- a/src/PSTree/Commands/GetPSTreeRegistryCommand.cs
+++ b/src/PSTree/Commands/GetPSTreeRegistryCommand.cs
@@ -125,8 +125,7 @@ public sealed class GetPSTreeRegistryCommand : TreeCommandBase
         return _cache.GetResult(WithInclude && !KeysOnly).Format();
     }
 
-    private bool ShouldSkipValue(string value) =>
-        string.IsNullOrEmpty(value) || ShouldExclude(value) || !ShouldInclude(value);
+    private bool ShouldSkipValue(string value) => ShouldExclude(value) || !ShouldInclude(value);
 
     private bool TryGetKey(string path, [NotNullWhen(true)] out RegistryKey? key)
     {

--- a/src/PSTree/Extensions/TreeExtensions.cs
+++ b/src/PSTree/Extensions/TreeExtensions.cs
@@ -84,6 +84,18 @@ internal static class TreeExtensions
         return tree;
     }
 
+    internal static void AddToCache<TBase, TLeaf>(this TLeaf leaf, Cache<TBase, TLeaf> cache)
+        where TLeaf : TBase
+        where TBase : ITree
+    {
+        cache.Add(leaf);
+    }
+
+    internal static void PushToStack(this TreeDirectory directory, Stack<TreeDirectory> stack)
+    {
+        stack.Push(directory);
+    }
+
 #if NETCOREAPP
     [SkipLocalsInit]
 #endif
@@ -186,6 +198,13 @@ internal static class TreeExtensions
     {
         treeKey.Item1.AddParent<TreeRegistryKey>(parent);
         return treeKey;
+    }
+
+    internal static void PushToStack(
+        this (TreeRegistryKey, RegistryKey) treeKey,
+        Stack<(TreeRegistryKey, RegistryKey)> stack)
+    {
+        stack.Push(treeKey);
     }
 
     internal static void Deconstruct(

--- a/src/PSTree/TreeDirectory.cs
+++ b/src/PSTree/TreeDirectory.cs
@@ -74,4 +74,14 @@ public sealed class TreeDirectory : TreeFileSystemInfo<DirectoryInfo>
             i.Length += length;
         }
     }
+
+    internal TreeDirectory SetIncludeFlagIf(bool condition)
+    {
+        if (condition)
+        {
+            Include = true;
+        }
+
+        return this;
+    }
 }

--- a/src/PSTree/TreeRegistryValue.cs
+++ b/src/PSTree/TreeRegistryValue.cs
@@ -9,6 +9,8 @@ public sealed class TreeRegistryValue : TreeRegistryBase
 {
     private readonly string _parentPath;
 
+    private readonly string _valueName;
+
     internal override bool Include { get; set; } = true;
 
     public RegistryValueKind Kind { get; }
@@ -22,14 +24,18 @@ public sealed class TreeRegistryValue : TreeRegistryBase
         base(string.Empty, source)
     {
         _parentPath = key.Name;
-        Kind = key.GetValueKind(value);
-        Hierarchy = GetColoredName(value, Kind).Indent(depth);
+        _valueName = value;
         Depth = depth;
-        Name = value;
+        Name = GetNameOrDefault(value);
+        Kind = key.GetValueKind(value);
+        Hierarchy = GetColoredName(Name, Kind).Indent(depth);
         PSParentPath = $"{_providerPath}{_parentPath}";
     }
 
-    public object? GetValue() => Registry.GetValue(_parentPath, Name, null);
+    private static string GetNameOrDefault(string value) =>
+        string.IsNullOrEmpty(value) ? "(Default)" : value;
+
+    public object? GetValue() => Registry.GetValue(_parentPath, _valueName, null);
 
     private static string GetColoredName(string name, RegistryValueKind kind) =>
         TreeStyle.Instance.Registry.GetColoredValue(name, kind);


### PR DESCRIPTION
This PR modifies the `Get-PSTreeRegistry` cmdlet to include registry default values (unnamed values displayed as `(Default)` in `regedit`), which were previously excluded due to a filter on empty value names.

### Impact of the Change

__Before__: `(Default)` values (empty-named registry values) were excluded from the output:

```powershell
PS ..\PSTree> Get-PSTreeRegistry Registry::HKEY_CLASSES_ROOT\LibreOffice.Pdf\shell\new

Kind         Hierarchy
----         ---------
RegistryKey  new
RegistryKey  └── command
```

__After__: `(Default)` values are now included:

```powershell
PS ..\PSTree> Get-PSTreeRegistry Registry::HKEY_CLASSES_ROOT\LibreOffice.Pdf\shell\new

Kind         Hierarchy
----         ---------
RegistryKey  new
String       ├── (Default)
RegistryKey  └── command
String           └── (Default)

PS ..\PSTree> (Get-PSTreeRegistry Registry::HKEY_CLASSES_ROOT\LibreOffice.Pdf\shell\new)[-1].GetValue()
"C:\Program Files\LibreOffice\program\sdraw.exe" -n "%1"
```

