### PR TITLE
Add Ctrl+C Cancellation Support and Ascending Sort Order for `Get-PSTreeRegistry`

### DIFF
--- a/src/PSTree/Extensions/TreeExtensions.cs
+++ b/src/PSTree/Extensions/TreeExtensions.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using Microsoft.Win32;
+using System.Linq;
 #if NETCOREAPP
 using System.Runtime.CompilerServices;
+#else
+using System.Text;
 #endif
 
 namespace PSTree.Extensions;
@@ -86,7 +88,7 @@ internal static class TreeExtensions
         return tree;
     }
 
-    internal static void AddToCache<TBase, TLeaf>(this TLeaf leaf, Cache<TBase, TLeaf> cache)
+    internal static void AddToCache<TBase, TLeaf>(this TLeaf leaf, TreeBuilder<TBase, TLeaf> cache)
         where TLeaf : TBase
         where TBase : ITree
     {
@@ -185,6 +187,13 @@ internal static class TreeExtensions
 
         return tree;
     }
+
+    internal static IEnumerable<string> EnumerateKeys(this RegistryKey registryKey) =>
+#if NET6_0_OR_GREATER
+        registryKey.GetSubKeyNames().OrderDescending();
+#else
+        registryKey.GetSubKeyNames().OrderByDescending(e => e);
+#endif
 
     internal static (TreeRegistryKey, RegistryKey) CreateTreeKey(
         this RegistryKey key, string name) =>

--- a/src/PSTree/TreeBuilder.cs
+++ b/src/PSTree/TreeBuilder.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace PSTree;
 
-internal sealed class Cache<TBase, TLeaf>
+internal sealed class TreeBuilder<TBase, TLeaf>
     where TLeaf : TBase
     where TBase : ITree
 {
@@ -15,7 +15,7 @@ internal sealed class Cache<TBase, TLeaf>
 
     internal void Add(TBase container) => _items.Add(container);
 
-    internal TBase[] GetResult(bool includeCondition) =>
+    internal TBase[] GetTree(bool includeCondition) =>
         includeCondition
             ? [.. _items.Where(static e => e.Include)]
             : [.. _items];

--- a/src/PSTree/TreeCommandBase.cs
+++ b/src/PSTree/TreeCommandBase.cs
@@ -15,11 +15,11 @@ public abstract class TreeCommandBase : PSCmdlet
 
     private WildcardPattern[]? _includePatterns;
 
+    private string[]? _paths;
+
     protected const string PathSet = "Path";
 
     protected const string LiteralPathSet = "LiteralPath";
-
-    protected string[]? _paths;
 
     protected bool WithExclude { get; private set; }
 
@@ -29,6 +29,8 @@ public abstract class TreeCommandBase : PSCmdlet
     {
         get => MyInvocation.BoundParameters.ContainsKey(nameof(LiteralPath));
     }
+
+    protected bool Canceled { get; set; }
 
     [Parameter(
         ParameterSetName = PathSet,
@@ -97,6 +99,8 @@ public abstract class TreeCommandBase : PSCmdlet
             WithInclude = true;
         }
     }
+
+    protected override void StopProcessing() => Canceled = true;
 
     protected IEnumerable<(ProviderInfo, string)> EnumerateResolvedPaths()
     {


### PR DESCRIPTION
## Description
This pull request addresses two issues:

1. **Ctrl+C Cancellation**: Added support for gracefully canceling operations using <kbd>Ctrl+C</kbd> when the cmdlet is traversing a registry hierarchy. Previously, the only way to stop the process was by restarting the session.
2. **Sort Order for Registry Keys**: Updated the `Get-PSTreeRegistry` cmdlet to sort Registry Keys in ascending order, resolving issue #9. The previous implementation sorted keys in descending order.

## Related Issues
- Fixes issue #9.