### PR TITLE
Add `-Top` parameter and tree consolidation logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -380,20 +380,20 @@ d----     └── Format                     1.83 Kb
 - `Type` property has been added to the output object and is now part of the _Default MemberSet_.
 
 [1]: https://github.com/santisq/PSTree/issues/9
-[2]: https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.getdirectories?view=net-6.0
-[3]: https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.getfiles?view=net-6.0
+[2]: https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.getdirectories
+[3]: https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.getfiles
 [4]: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-childitem
-[5]: https://docs.microsoft.com/en-us/dotnet/api/system.collections.stack?view=net-6.0
+[5]: https://docs.microsoft.com/en-us/dotnet/api/system.collections.stack
 [6]: https://github.com/IISResetMe
-[7]: https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.stack-1?view=net-6.0
-[8]: https://docs.microsoft.com/en-us/dotnet/api/system.io.directoryinfo?view=net-6.0
-[9]: https://docs.microsoft.com/en-us/dotnet/api/system.io.directoryinfo.getfiles?view=net-6.0#system-io-directoryinfo-getfiles
-[10]: https://docs.microsoft.com/en-us/dotnet/api/system.io.directoryinfo.getdirectories?view=net-6.0#system-io-directoryinfo-getdirectories
-[11]: https://docs.microsoft.com/en-us/dotnet/api/system.io.directoryinfo.enumeratefilesysteminfos?view=net-6.0#system-io-directoryinfo-enumeratefilesysteminfos
+[7]: https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.stack-1
+[8]: https://docs.microsoft.com/en-us/dotnet/api/system.io.directoryinfo
+[9]: https://docs.microsoft.com/en-us/dotnet/api/system.io.directoryinfo.getfiles#system-io-directoryinfo-getfiles
+[10]: https://docs.microsoft.com/en-us/dotnet/api/system.io.directoryinfo.getdirectories#system-io-directoryinfo-getdirectories
+[11]: https://docs.microsoft.com/en-us/dotnet/api/system.io.directoryinfo.enumeratefilesysteminfos#system-io-directoryinfo-enumeratefilesysteminfos
 [12]: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_format.ps1xml?view=powershell-7.2&viewFallbackFrom=powershell-6
 [13]: PSTree/PSTree.Format.ps1xml
-[14]: https://learn.microsoft.com/en-us/dotnet/api/system.io.filesysteminfo.tostring?view=net-7.0#system-io-filesysteminfo-tostring
-[15]: https://learn.microsoft.com/en-us/dotnet/api/system.io.filesysteminfo.refresh?view=net-7.0#system-io-filesysteminfo-refresh
+[14]: https://learn.microsoft.com/en-us/dotnet/api/system.io.filesysteminfo.tostring#system-io-filesysteminfo-tostring
+[15]: https://learn.microsoft.com/en-us/dotnet/api/system.io.filesysteminfo.refresh#system-io-filesysteminfo-refresh
 [16]: https://app.codecov.io/gh/santisq/PSTree
 [17]: https://github.com/SeeminglyScience/
 [18]: https://github.com/jborean93/

--- a/README.md
+++ b/README.md
@@ -64,19 +64,19 @@ Set-Location ./PSTree
 #### Get the current directory tree with default parameters values
 
 ```powershell
-PS \> Get-PSTree | Select-Object -First 20
+PS \> Get-PSTree
 
-   Source: C:\User\Documents\PSTree
+   Source: D:\pwsh\PSTree
 
 Mode            Length Hierarchy
 ----            ------ ---------
-d----         36.78 KB PSTree
--a---          4.75 KB ├── .gitignore        
+d----         37.54 KB PSTree
+-a---          4.75 KB ├── .gitignore
 -a---        137.00  B ├── .markdownlint.json
 -a---          1.37 KB ├── build.ps1
--a---         19.34 KB ├── CHANGELOG.md
+-a---         19.73 KB ├── CHANGELOG.md
 -a---          1.07 KB ├── LICENSE
--a---         10.12 KB ├── README.md
+-a---         10.48 KB ├── README.md
 d----          0.00  B ├── .github
 d----          4.10 KB │   └── workflows
 -a---          4.10 KB │       └── ci.yml
@@ -85,98 +85,129 @@ d----          4.18 KB ├── .vscode
 -a---          1.39 KB │   ├── launch.json
 -a---          1.09 KB │   ├── settings.json
 -a---          1.43 KB │   └── tasks.json
-d----        266.71 KB ├── assets
--a---         10.00 KB │   ├── EscapeSequence.png
--a---         78.08 KB │   ├── Get-PSTree.After.png
--a---         73.89 KB │   ├── Get-PSTree.Before.png
--a---         34.54 KB │   ├── Get-PSTreeRegistry.After.png
+d----        491.24 KB ├── assets
+-a---         95.47 KB │   ├── ClassicStyles.png
+-a---         96.12 KB │   ├── FancyStyles.png
+-a---         66.76 KB │   ├── Get-PSTree.After.png
+-a---         63.05 KB │   ├── Get-PSTree.Before.png
+...
 ```
 
 #### Excludes items starting with `.g`, `.v`, `.m` and `assets`
 
 ```powershell
-PS \> Get-PSTree -Exclude .[gvm]*, assets | Select-Object -First 20
+PS \> Get-PSTree -Exclude .[gvm]*, assets
 
-   Source: C:\User\Documents\PSTree
+   Source: D:\pwsh\PSTree
 
 Mode            Length Hierarchy
 ----            ------ ---------
-d----         31.90 KB PSTree
--a---          1.37 KB ├── build.ps1   
--a---         19.34 KB ├── CHANGELOG.md
+d----         32.65 KB PSTree
+-a---          1.37 KB ├── build.ps1
+-a---         19.73 KB ├── CHANGELOG.md
 -a---          1.07 KB ├── LICENSE
--a---         10.12 KB ├── README.md
+-a---         10.48 KB ├── README.md
 d----          0.00  B ├── docs
-d----         31.99 KB │   └── en-US
--a---          7.25 KB │       ├── about_TreeStyle.md
--a---         13.25 KB │       ├── Get-PSTree.md
--a---         10.49 KB │       ├── Get-PSTreeRegistry.md
--a---          1.00 KB │       └── Get-PSTreeStyle.md
-d----         22.10 KB ├── module
--a---         17.08 KB │   ├── PSTree.Format.ps1xml
--a---          5.01 KB │   └── PSTree.psd1
-d----        513.42 KB ├── output
--a---         22.70 KB │   ├── PSTree.2.1.11.nupkg
--a---         24.21 KB │   ├── PSTree.2.1.12.nupkg
--a---         24.22 KB │   ├── PSTree.2.1.13.nupkg
--a---         24.42 KB │   ├── PSTree.2.1.14.nupkg
--a---         25.07 KB │   ├── PSTree.2.1.15.nupkg
+d----         36.81 KB │   └── en-US
+-a---          6.68 KB │       ├── about_TreeStyle.md
+-a---         16.90 KB │       ├── Get-PSTree.md
+-a---         11.84 KB │       ├── Get-PSTreeRegistry.md
+-a---          1.39 KB │       └── Get-PSTreeStyle.md
+d----         22.39 KB ├── module
+-a---         17.25 KB │   ├── PSTree.Format.ps1xml
+-a---          5.14 KB │   └── PSTree.psd1
+d----        106.22 KB ├── output
+-a---        106.22 KB │   ├── PSTree.3.0.0.nupkg
+d----          0.00  B │   ├── PSTree
+d----          0.00  B │   │   └── 3.0.0
+d----        277.39 KB │   └── TestResults
+-a---        249.51 KB │       ├── Coverage.xml
+...
 ```
 
-#### Includes `.ps1` and `.cs` files and excludes `tools` folder
+#### Includes `.ps1` and `.cs` files, excludes `tools` folder and sorts items by size
 
 ```powershell
-PS \> Get-PStree -Include *.ps1, *.cs -Exclude tools
+PS \> Get-PSTree -Depth 4 -Include *.ps1, *.cs -Exclude tools -SortBy Size
 
-   Source: C:\User\Documents\PSTree
+   Source: D:\pwsh\PSTree
 
 Mode            Length Hierarchy
 ----            ------ ---------
 d----          1.37 KB PSTree
+d----         29.54 KB ├── tests
+-a---          9.29 KB │   ├── TreeStyle.tests.ps1
+-a---          7.35 KB │   ├── GetPSTreeRegistryCommand.tests.ps1
+-a---          7.33 KB │   ├── GetPSTreeCommand.tests.ps1
+-a---          2.46 KB │   ├── TreeFileSystemInfo_T.tests.ps1
+-a---          1.59 KB │   ├── TreeDirectory.tests.ps1
+-a---        804.00  B │   ├── FormattingInternals.tests.ps1
+-a---        745.00  B │   └── TreeFile.tests.ps1
 -a---          1.37 KB ├── build.ps1
-d----          0.00  B ├── src
-d----         15.87 KB │   └── PSTree
--a---        839.00  B │       ├── Cache.cs
--a---        169.00  B │       ├── ITree.cs
--a---        674.00  B │       ├── RegistryMappings.cs
--a---          1.02 KB │       ├── TreeBase.cs
--a---          4.00 KB │       ├── TreeCommandBase.cs
--a---        438.00  B │       ├── TreeComparer.cs
--a---          2.27 KB │       ├── TreeDirectory.cs
--a---          1.30 KB │       ├── TreeFile.cs
--a---          1.68 KB │       ├── TreeFileSystemInfo_T.cs
--a---        311.00  B │       ├── TreeFileSystemInfo.cs
--a---        942.00  B │       ├── TreeRegistryBase.cs
--a---          1.10 KB │       ├── TreeRegistryKey.cs
--a---          1.21 KB │       └── TreeRegistryValue.cs
-d----         27.48 KB └── tests
--a---        985.00  B     ├── FormattingInternals.tests.ps1
--a---          6.13 KB     ├── GetPSTreeCommand.tests.ps1
--a---          6.44 KB     ├── GetPSTreeRegistryCommand.tests.ps1
--a---          1.77 KB     ├── TreeDirectory.tests.ps1
--a---        914.00  B     ├── TreeFile.tests.ps1
--a---          2.62 KB     ├── TreeFileSystemInfo_T.tests.ps1
--a---          8.67 KB     └── TreeStyle.tests.ps1
+d----          0.00  B └── src
+d----          0.00  B     └── PSTree
+d----         13.73 KB         ├── Nodes
+-a---          3.61 KB         │   ├── TreeBase.cs
+-a---          2.55 KB         │   ├── TreeRegistryKey.cs
+-a---          2.30 KB         │   ├── TreeDirectory.cs
+-a---          1.43 KB         │   ├── TreeFileSystemInfo_T.cs
+-a---          1.15 KB         │   ├── TreeRegistryValue.cs
+-a---        967.00  B         │   ├── TreeSummary.cs
+-a---        714.00  B         │   ├── TreeFileSystemInfo.cs
+...
 ```
 
 #### Get the recursive size of the folders
 
 ```powershell
-PS \> Get-PSTree .\src\ -Depth 2 -Directory -RecursiveSize
+PS \> Get-PSTree .\src -Depth 2 -Directory -RecursiveSize
 
-   Source: C:\User\Documents\PSTree\src
+   Source: D:\pwsh\PSTree\src
 
 Mode            Length Hierarchy
 ----            ------ ---------
-d----          1.04 MB src
-d----          1.04 MB └── PSTree
-d----        670.05 KB     ├── bin
-d----          7.53 KB     ├── CodeAnalysis
-d----         10.58 KB     ├── Commands
-d----          8.01 KB     ├── Extensions
-d----          1.29 KB     ├── Internal
-d----        341.03 KB     ├── obj
-d----         11.69 KB     └── Style
+d----          1.15 MB src
+d----          1.15 MB └── PSTree
+d----        732.37 KB     ├── bin
+d----          7.81 KB     ├── CodeAnalysis
+d----         13.17 KB     ├── Commands
+d----          6.51 KB     ├── Comparers
+d----          7.50 KB     ├── Extensions
+d----        331.00  B     ├── Interfaces
+d----        948.00  B     ├── Internal
+d----         13.73 KB     ├── Nodes
+d----        374.92 KB     ├── obj
+d----          2.35 KB     ├── Registry
+d----         12.53 KB     └── Style
+```
+
+#### Get the top N items at each level using `-Top`
+
+```powershell
+PS \> Get-PSTree .\src\PSTree -Top 3
+
+   Source: D:\pwsh\PSTree\src\PSTree
+
+Mode            Length Hierarchy
+----            ------ ---------
+d----          1.15 MB PSTree
+d----        732.37 KB ├── bin
+d----        732.37 KB │   └── Debug
+d----        502.91 KB │       ├── net472
+d----        229.46 KB │       └── net8.0
+d----        374.92 KB ├── obj
+d----        286.14 KB │   ├── Debug
+d----        198.00 KB │   │   ├── net8.0
+d----         88.14 KB │   │   └── net472
+-a---         79.42 KB │   ├── project.assets.json
+-a---          4.02 KB │   ├── project.nuget.cache
+-----          5.34 KB │   └── [+3 files]
+d----         13.73 KB ├── Nodes
+-a---          3.61 KB │   ├── TreeBase.cs
+-a---          2.55 KB │   ├── TreeRegistryKey.cs
+-a---          2.30 KB │   ├── TreeDirectory.cs
+-----          5.27 KB │   └── [+6 files]
+-----         52.69 KB └── [+8 folders, +1 file]
 ```
 
 ### `Get-PSTreeRegistry`
@@ -263,7 +294,7 @@ RegistryKey      └── Control
 
 ```powershell
 PS \> $items = Get-PSTreeRegistry HKCU:\Environment\ -Depth 2
-PS \> $values = $items | Where-Object { $_ -is [PSTree.TreeRegistryValue] }
+PS \> $values = $items | Where-Object { $_ -is [PSTree.Nodes.TreeRegistryValue] }
 PS \> $values
 
    Hive: HKEY_CURRENT_USER\Environment

--- a/docs/en-US/Get-PSTree.md
+++ b/docs/en-US/Get-PSTree.md
@@ -25,6 +25,8 @@ Get-PSTree
     [-RecursiveSize]
     [-Exclude <String[]>]
     [-Include <String[]>]
+    [-SortBy <FileSystemSortMode>]
+    [-Top <Int32>]
     [<CommonParameters>]
 ```
 
@@ -40,6 +42,8 @@ Get-PSTree
     [-RecursiveSize]
     [-Exclude <String[]>]
     [-Include <String[]>]
+    [-SortBy <FileSystemSortMode>]
+    [-Top <Int32>]
     [<CommonParameters>]
 ```
 
@@ -72,6 +76,7 @@ PS \> Get-PSTree $HOME -Depth 2 -Force
 ```
 
 > [!TIP]
+>
 > The `-Force` switch is required to include hidden files and folders in the output. Additionally, hidden items contribute to folder sizes (including recursive sizes with [`-RecursiveSize`](#-recursivesize), if specified), ensuring a comprehensive view of disk usage.
 
 ### Example 4: Display the `C:\` Drive Tree, Limited to 2 Levels, Showing Only Directories with Recursive Sizes
@@ -102,6 +107,7 @@ PS \> Get-ChildItem -Directory | Get-PSTree
 ```
 
 > [!TIP]
+>
 > Output from cmdlets that work with the file system and return `System.IO.FileSystemInfo` objects (e.g., `Get-ChildItem`, `Get-Item`) can be piped to `Get-PSTree`. Pipeline input is bound to the `-LiteralPath` parameter if the objects have a `PSPath` property, enabling seamless traversal of multiple directory structures with default settings (depth of 3, no recursion unless specified).
 
 This example pipes the output of `Get-ChildItem` to `Get-PSTree`, retrieving the directory and file structure for each directory in the current location. It displays hierarchies with default depth (3 levels) and folder sizes, excluding hidden or system items unless [`-Force`](#-force) is used.
@@ -134,6 +140,19 @@ PS \> Get-PSTree -SortBy FilesFirstBySize
 # Disable sorting for best performance
 PS \> Get-PSTree -SortBy None
 ```
+
+### Example 9: Display only the largest items at each level using -Top
+
+```powershell
+PS \> Get-PSTree -Top 10
+PS \> Get-PSTree C:\Users -Top 5 -SortBy DirectoriesFirstBySize -Depth 4
+```
+
+This example displays only the 10 largest items (by size) at each directory level. A `TreeSummary` object is added at the end of each truncated directory showing the number of omitted folders/files and their total size.
+
+> [!TIP]
+>
+> The `-Top` parameter works best with size-based sorting and is very useful for quickly identifying the largest consumers of disk space without rendering the full tree.
 
 ## PARAMETERS
 
@@ -262,7 +281,7 @@ Accept wildcard characters: True
 
 ### -Recurse
 
-Enables recursive traversal of all subfolders under the specified path. Use this switch to explore the complete folder hierarchy, but note that it may impact performance on large directories—consider ][`-Depth`](#-depth) for smaller subsets.
+Enables recursive traversal of all subfolders under the specified path. Use this switch to explore the complete folder hierarchy, but note that it may impact performance on large directories—consider [`-Depth`](#-depth) for smaller subsets.
 
 ```yaml
 Type: SwitchParameter
@@ -326,6 +345,27 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Top
+
+Specifies the maximum number of items to display at each directory level (after sorting). When used, the cmdlet keeps only the top __N__ items per directory and appends a `TreeSummary` object with the count and total size of the omitted items.
+
+> [!IMPORTANT]
+>
+> - Using `-Top` automatically enables `-RecursiveSize` and sets `-SortBy Size` (unless another sort mode is explicitly provided).
+> - `-Top` only works with size-based sorting (`Size` or `DirectoriesFirstBySize`). Using it with other sort modes throws a terminating error.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases: t
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
 
 This cmdlet supports the common parameters. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
@@ -339,13 +379,22 @@ Output from cmdlets that return `System.IO.FileSystemInfo` objects (e.g., `Get-I
 
 ## OUTPUTS
 
-### PSTree.TreeDirectory
+### PSTree.Nodes.TreeDirectory
 
 Returns objects of type `TreeDirectory` representing directories in a hierarchical structure, with `TreeFile` objects included as children. Each `TreeDirectory` object includes properties such as `Name`, `FullName`, `Size`, and `Depth`, reflecting the file system organization and enabling size-based analysis. This prioritizes directories as the primary output type for tree navigation, with files nested within for comprehensive exploration.
 
-### PSTree.TreeFile
+### PSTree.Nodes.TreeFile
 
 Returns objects of type `TreeFile` representing files within directories, included in the output unless the `-Directory` parameter is specified. Each object includes properties such as `Name`, `FullName`, `Size`, and `Depth`, allowing detailed file analysis within the hierarchical structure. These objects are nested under `TreeDirectory` objects, supporting disk usage tracking and file system navigation.
+
+### PSTree.Nodes.TreeSummary
+
+A placeholder object added when the `-Top` parameter is used and a directory exceeds the specified number of items. It represents the truncated items by showing the count of omitted folders and files along with their combined size.
+
+__Main properties:__
+
+- `Name` — Summary string in the form `[+N folders, +M files]`, `[+N folders]`, or `[+M files]`
+- `Length` — Total size of all truncated items
 
 ## NOTES
 

--- a/docs/en-US/Get-PSTreeRegistry.md
+++ b/docs/en-US/Get-PSTreeRegistry.md
@@ -23,6 +23,7 @@ Get-PSTreeRegistry
     [-KeysOnly]
     [-Exclude <String[]>]
     [-Include <String[]>]
+    [-SortBy <RegistrySortMode>]
     [<CommonParameters>]
 ```
 
@@ -36,6 +37,7 @@ Get-PSTreeRegistry
     [-KeysOnly]
     [-Exclude <String[]>]
     [-Include <String[]>]
+    [-SortBy <RegistrySortMode>]
     [<CommonParameters>]
 ```
 
@@ -65,7 +67,7 @@ This example restricts output to keys only (no values) and limits the depth to 2
 
 ```powershell
 PS \> $items = Get-PSTreeRegistry HKCU:\Environment\ -Depth 2
-PS \> $values = $items | Where-Object { $_ -is [PSTree.TreeRegistryValue] }
+PS \> $values = $items | Where-Object { $_ -is [PSTree.Nodes.TreeRegistryValue] }
 PS \> $values
 
    Hive: HKEY_CURRENT_USER\Environment
@@ -168,6 +170,7 @@ Accept wildcard characters: False
 Specifies the literal registry paths to traverse, without wildcard expansion. This parameter accepts input from the pipeline by property name (using the `PSPath` alias). Use this for exact path matching, bypassing wildcard interpretation.  
 
 > [!TIP]
+>
 > For registry base keys not mapped as PowerShell drives (e.g., `HKCU:\` and `HKLM:\`), you can use the provider path format by prefixing the path with `Registry::`. For example, to traverse all keys under `HKEY_USERS` exactly as specified, use: `Get-PSTreeRegistry -LiteralPath Registry::HKEY_USERS`.
 
 ```yaml
@@ -187,6 +190,7 @@ Accept wildcard characters: False
 Specifies the registry paths to traverse. Accepts one or more registry paths (e.g., `HKLM:\Software`, `HKCU:\Software`), which can include [wildcard characters](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_wildcards?view=powershell-7.5). This parameter can accept input from the pipeline. Paths are resolved using [PowerShell's registry provider](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_registry_provider?view=powershell-7.5).  
 
 > [!TIP]
+>
 > For registry base keys not mapped as PowerShell drives (e.g., `HKCU:\` and `HKLM:\`), you can use the provider path format by prefixing the path with `Registry::`. For example, to traverse each key under `HKEY_USERS`, use: `Get-PSTreeRegistry -Path Registry::HKEY_USERS\*`.
 
 ```yaml
@@ -274,6 +278,7 @@ __Valid values:__
 - `None` — No sorting is performed (maximum performance). Items appear in the order they were discovered.
 
 > [!TIP]
+>
 > Use `-SortBy None` when performance is critical and the natural discovery order is sufficient.
 
 ```yaml
@@ -301,11 +306,11 @@ Output from cmdlets that return `Microsoft.Win32.RegistryKey` objects (e.g., `Ge
 
 ## OUTPUTS
 
-### PSTree.TreeRegistryKey
+### PSTree.Nodes.TreeRegistryKey
 
 Returns objects of type `TreeRegistryKey` representing registry keys in a hierarchical structure. If `-KeysOnly` is specified, only `TreeRegistryKey` objects are returned; otherwise, `TreeRegistryValue` objects may also be included, but the primary output type remains `TreeRegistryKey` for consistency with the tree-like organization.
 
-### PSTree.TreeRegistryValue
+### PSTree.Nodes.TreeRegistryValue
 
 Returns objects of type `TreeRegistryValue` representing registry values associated with keys, included in the output unless the `-KeysOnly` parameter is specified. Each object includes properties such as `Name`, `Kind`, and `Depth`, allowing access to value data (e.g., via the `.GetValue()` method). These objects are nested under `TreeRegistryKey` objects in the hierarchical output, providing detailed value information for registry exploration.
 
@@ -315,7 +320,7 @@ This cmdlet is Windows-only and requires PowerShell 5.1 or later. It may require
 
 ## RELATED LINKS
 
-[__Microsoft.Win32 Namespace__](https://learn.microsoft.com/en-us/dotnet/api/microsoft.win32?view=net-9.0)
+[__Microsoft.Win32 Namespace__](https://learn.microsoft.com/en-us/dotnet/api/microsoft.win32)
 
 [__about_Registry_Provider__](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_registry_provider?view=powershell-7.5)
 

--- a/src/PSTree/CodeAnalysis/Poly.cs
+++ b/src/PSTree/CodeAnalysis/Poly.cs
@@ -1,0 +1,11 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace PSTree.CodeAnalysis;
+
+[ExcludeFromCodeCoverage]
+internal static class Poly
+{
+    [Conditional("DEBUG")]
+    internal static void Assert([DoesNotReturnIf(false)] bool condition) => Debug.Assert(condition);
+}

--- a/src/PSTree/Commands/GetPSTreeCommand.cs
+++ b/src/PSTree/Commands/GetPSTreeCommand.cs
@@ -27,6 +27,36 @@ public sealed class GetPSTreeCommand
     [Alias("rs")]
     public SwitchParameter RecursiveSize { get; set; }
 
+    [Parameter]
+    [Alias("t")]
+    [ValidateRange(1, int.MaxValue)]
+    public override int Top { get; set; }
+
+    protected override void BeginProcessing()
+    {
+        if (MyInvocation.Uses(nameof(Top)))
+        {
+            (bool IsBound, bool IsValid) = CheckSortMode();
+
+            if (!IsValid) this.ThrowIncompatibleSortError();
+
+            RecursiveSize = true;
+            if (!IsBound) SortBy = FileSystemSortMode.Size;
+        }
+
+        base.BeginProcessing();
+    }
+
+    private (bool IsBound, bool IsValid) CheckSortMode()
+    {
+        bool bound = MyInvocation.Uses(nameof(SortBy));
+        bool valid = !bound || SortBy
+            is FileSystemSortMode.Size
+            or FileSystemSortMode.DirectoriesFirstBySize;
+
+        return (bound, valid);
+    }
+
     protected override void ProcessRecord()
     {
         foreach ((ProviderInfo provider, string path) in EnumerateResolvedPaths())
@@ -50,7 +80,7 @@ public sealed class GetPSTreeCommand
 
             if (!System.IO.Directory.Exists(path))
             {
-                WriteError(path.ToInvalidPathError());
+                this.WriteInvalidPathError(path);
                 continue;
             }
 
@@ -64,6 +94,7 @@ public sealed class GetPSTreeCommand
         bool showThisLevel = depth <= Depth;
         bool shouldTraverse = showThisLevel || RecursiveSize;
         bool hasFile = false;
+        string source = current.Source;
 
         try
         {
@@ -74,7 +105,7 @@ public sealed class GetPSTreeCommand
 
                 if (item is DirectoryInfo dir)
                 {
-                    TreeDirectory treedir = current.CreateDirectory(dir, CurrentSource);
+                    TreeDirectory treedir = current.CreateDirectory(dir, source);
 
                     if (showThisLevel)
                         current.AddChild(treedir);
@@ -95,14 +126,14 @@ public sealed class GetPSTreeCommand
                     continue;
 
                 hasFile = true;
-                TreeFile treefile = current.CreateFile(file, CurrentSource);
+                TreeFile treefile = current.CreateFile(file, source);
                 current.AddChild(treefile);
             }
 
             current.AggregateUp(
                 accumulatedLength,
                 RecursiveSize,
-                WithInclude && hasFile);
+                HasInclude && hasFile);
         }
         catch (Exception exception)
         {

--- a/src/PSTree/Commands/GetPSTreeCommand.cs
+++ b/src/PSTree/Commands/GetPSTreeCommand.cs
@@ -10,7 +10,7 @@ using PSTree.Nodes;
 namespace PSTree.Commands;
 
 [Cmdlet(VerbsCommon.Get, "PSTree", DefaultParameterSetName = PathSet)]
-[OutputType(typeof(TreeDirectory), typeof(TreeFile))]
+[OutputType(typeof(TreeDirectory), typeof(TreeFile), typeof(TreeSummary))]
 [Alias("pstree")]
 public sealed class GetPSTreeCommand
     : TreeCommandBase<TreeDirectory, TreeFileSystemInfo, FileSystemSortMode>

--- a/src/PSTree/Commands/GetPSTreeRegistryCommand.cs
+++ b/src/PSTree/Commands/GetPSTreeRegistryCommand.cs
@@ -41,6 +41,7 @@ public sealed class GetPSTreeRegistryCommand
     protected override void BuildOne(TreeRegistryKey current, int depth)
     {
         bool hasValue = false;
+        string source = current.Source;
 
         using (current)
         {
@@ -51,7 +52,7 @@ public sealed class GetPSTreeRegistryCommand
                 {
                     if (!ShouldSkipValue(value))
                     {
-                        current.AddValue(value, CurrentSource);
+                        current.AddValue(value, source);
                         hasValue = true;
                     }
                 }
@@ -63,8 +64,8 @@ public sealed class GetPSTreeRegistryCommand
 
                 try
                 {
-                    if (current.TryAddSubKey(name, CurrentSource, out TreeRegistryKey? subKey))
-                        Push(subKey);
+                    if (current.TryAddSubKey(name, source, out TreeRegistryKey? subk))
+                        Push(subk);
                 }
                 catch (SecurityException exception)
                 {
@@ -73,7 +74,7 @@ public sealed class GetPSTreeRegistryCommand
                 }
             }
 
-            if (WithInclude && hasValue)
+            if (HasInclude && hasValue)
                 current.PropagateInclude();
         }
     }
@@ -94,7 +95,7 @@ public sealed class GetPSTreeRegistryCommand
             {
                 if ((key = value.OpenSubKey(subKey)) is null)
                 {
-                    WriteError(path.ToInvalidPathError());
+                    this.WriteInvalidPathError(path);
                     return false;
                 }
             }

--- a/src/PSTree/Commands/TreeCommandBase.cs
+++ b/src/PSTree/Commands/TreeCommandBase.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Management.Automation;
+using PSTree.CodeAnalysis;
 using PSTree.Extensions;
 using PSTree.Nodes;
 
@@ -175,6 +176,7 @@ public abstract class TreeCommandBase<TContainer, TBase, TSort> : PSCmdlet
 
         return false;
     }
+
 
     protected bool ShouldInclude(string item) =>
         !HasInclude || MatchAny(item, _includePatterns!);

--- a/src/PSTree/Commands/TreeCommandBase.cs
+++ b/src/PSTree/Commands/TreeCommandBase.cs
@@ -19,6 +19,8 @@ public abstract class TreeCommandBase<TContainer, TBase, TSort> : PSCmdlet
 
     private readonly Stack<TContainer> _stack = new(32);
 
+    private IComparer<TBase>? _comparer;
+
     private WildcardPattern[]? _excludePatterns;
 
     private WildcardPattern[]? _includePatterns;
@@ -29,9 +31,7 @@ public abstract class TreeCommandBase<TContainer, TBase, TSort> : PSCmdlet
 
     protected const string LiteralPathSet = "LiteralPath";
 
-    protected bool WithInclude { get; private set; }
-
-    protected string CurrentSource { get; private set; } = null!;
+    protected bool HasInclude { get; private set; }
 
     [Parameter(
         ParameterSetName = PathSet,
@@ -81,6 +81,8 @@ public abstract class TreeCommandBase<TContainer, TBase, TSort> : PSCmdlet
     [Alias("sb")]
     public TSort SortBy { get; set; }
 
+    public virtual int Top { get; set; }
+
     protected override void BeginProcessing()
     {
         if (Recurse && !MyInvocation.BoundParameters.ContainsKey(nameof(Depth)))
@@ -96,8 +98,10 @@ public abstract class TreeCommandBase<TContainer, TBase, TSort> : PSCmdlet
         if (Include is not null)
         {
             _includePatterns = [.. Include.Select(e => new WildcardPattern(e, options))];
-            WithInclude = true;
+            HasInclude = true;
         }
+
+        _comparer = GetComparer();
     }
 
     protected IEnumerable<(ProviderInfo, string)> EnumerateResolvedPaths()
@@ -136,7 +140,6 @@ public abstract class TreeCommandBase<TContainer, TBase, TSort> : PSCmdlet
     protected void ProcessTree(TContainer container)
     {
         int depth, maxdp = 0;
-        CurrentSource = container.Source;
         Push(container);
 
         while (!_canceled && _stack.Count > 0)
@@ -147,11 +150,10 @@ public abstract class TreeCommandBase<TContainer, TBase, TSort> : PSCmdlet
             BuildOne(current, depth);
         }
 
-        IComparer<TBase>? comparer = GetComparer();
-        if (WithInclude) container.PruneNonIncluded();
+        container.Consolidate(_comparer, Top, HasInclude);
 
         WriteObject(
-            container.Render(maxdp, comparer),
+            container.Render(maxdp),
             enumerateCollection: true);
     }
 
@@ -175,7 +177,7 @@ public abstract class TreeCommandBase<TContainer, TBase, TSort> : PSCmdlet
     }
 
     protected bool ShouldInclude(string item) =>
-        !WithInclude || MatchAny(item, _includePatterns!);
+        !HasInclude || MatchAny(item, _includePatterns!);
 
     protected bool ShouldExclude(string item) =>
         _excludePatterns is not null && MatchAny(item, _excludePatterns);

--- a/src/PSTree/Commands/TreeCommandBase.cs
+++ b/src/PSTree/Commands/TreeCommandBase.cs
@@ -86,7 +86,7 @@ public abstract class TreeCommandBase<TContainer, TBase, TSort> : PSCmdlet
 
     protected override void BeginProcessing()
     {
-        if (Recurse && !MyInvocation.BoundParameters.ContainsKey(nameof(Depth)))
+        if (Recurse && !MyInvocation.Uses(nameof(Depth)))
             Depth = int.MaxValue;
 
         const WildcardOptions options = WildcardOptions.Compiled
@@ -112,7 +112,7 @@ public abstract class TreeCommandBase<TContainer, TBase, TSort> : PSCmdlet
 
         foreach (string path in _paths ?? [SessionState.Path.CurrentLocation.Path])
         {
-            if (MyInvocation.BoundParameters.ContainsKey(nameof(LiteralPath)))
+            if (MyInvocation.Uses(nameof(LiteralPath)))
             {
                 string resolved = SessionState.Path.GetUnresolvedProviderPathFromPSPath(
                     path: path,
@@ -177,9 +177,12 @@ public abstract class TreeCommandBase<TContainer, TBase, TSort> : PSCmdlet
         return false;
     }
 
-
-    protected bool ShouldInclude(string item) =>
-        !HasInclude || MatchAny(item, _includePatterns!);
+    protected bool ShouldInclude(string item)
+    {
+        if (!HasInclude) return true;
+        Poly.Assert(_includePatterns is not null);
+        return MatchAny(item, _includePatterns);
+    }
 
     protected bool ShouldExclude(string item) =>
         _excludePatterns is not null && MatchAny(item, _excludePatterns);

--- a/src/PSTree/Extensions/ExceptionExtensions.cs
+++ b/src/PSTree/Extensions/ExceptionExtensions.cs
@@ -29,10 +29,21 @@ internal static class ExceptionExtensions
             => new(exception, "EnumerationFailure", ErrorCategory.NotSpecified, item);
     }
 
-    internal static ErrorRecord ToInvalidPathError(this string path)
+    extension(PSCmdlet cmdlet)
     {
-        ItemNotFoundException exception = new($"Cannot find path '{path}' because it does not exist.");
-        return new(exception,"InvalidPath", ErrorCategory.InvalidArgument, path);
+        internal void WriteInvalidPathError(string path)
+        {
+            ItemNotFoundException ex = new($"Cannot find path '{path}' because it does not exist.");
+            ErrorRecord error = new(ex, "InvalidPath", ErrorCategory.InvalidArgument, path);
+            cmdlet.WriteError(error);
+        }
+
+        internal void ThrowIncompatibleSortError()
+        {
+            InvalidOperationException ex = new("The -Top parameter requires a size-based sort mode (Size or DirectoriesFirstBySize).");
+            ErrorRecord error = new(ex, "InvalidSortForTop", ErrorCategory.InvalidArgument, null);
+            cmdlet.ThrowTerminatingError(error);
+        }
     }
 
     internal static void ThrowInvalidSequence(this string vt)

--- a/src/PSTree/Extensions/MiscExtensions.cs
+++ b/src/PSTree/Extensions/MiscExtensions.cs
@@ -1,5 +1,5 @@
-#if WINDOWS
 using System.IO;
+using System.Management.Automation;
 using Microsoft.Win32;
 using PSTree.Nodes;
 
@@ -7,6 +7,13 @@ namespace PSTree.Extensions;
 
 internal static class MiscExtensions
 {
+    extension(InvocationInfo invocation)
+    {
+        internal bool Uses(string parameter)
+            => invocation.BoundParameters.ContainsKey(parameter);
+    }
+
+#if WINDOWS
     extension(string[] values)
     {
         internal void Deconstruct(out string baseKey, out string? subKey)
@@ -15,12 +22,6 @@ internal static class MiscExtensions
             subKey = values.Length == 1 ? null : values[1];
         }
     }
-
-    extension(string value)
-    {
-
-    }
-
 
     extension(RegistryKey registryKey)
     {
@@ -43,5 +44,5 @@ internal static class MiscExtensions
     {
         internal string JoinPath(string leaf) => Path.Combine(treeKey.Path, leaf);
     }
-}
 #endif
+}

--- a/src/PSTree/Extensions/TreeFormattingExtensions.cs
+++ b/src/PSTree/Extensions/TreeFormattingExtensions.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Text;
 using PSTree.Interfaces;
 using PSTree.Nodes;
@@ -29,7 +28,7 @@ internal static class TreeFormattingExtension
                 TreeRegistryKey key => builder.GetStyledName(key),
                 TreeRegistryValue value => builder.GetStyledName(value),
 #endif
-                _ => throw new ArgumentOutOfRangeException(nameof(tree))
+                _ => builder.Append(tree.Name).ToString()
             };
 
         private string GetStyledName(TreeDirectory directory)

--- a/src/PSTree/Extensions/TreeFormattingExtensions.cs
+++ b/src/PSTree/Extensions/TreeFormattingExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using PSTree.Interfaces;
 using PSTree.Nodes;
@@ -24,11 +25,12 @@ internal static class TreeFormattingExtension
             {
                 TreeDirectory dir => builder.GetStyledName(dir),
                 TreeFile file => builder.GetStyledName(file),
+                TreeSummary summary => builder.GetStyledName(summary),
 #if WINDOWS
                 TreeRegistryKey key => builder.GetStyledName(key),
                 TreeRegistryValue value => builder.GetStyledName(value),
 #endif
-                _ => builder.Append(tree.Name).ToString()
+                _ => throw new ArgumentOutOfRangeException(nameof(tree))
             };
 
         private string GetStyledName(TreeDirectory directory)
@@ -68,6 +70,20 @@ internal static class TreeFormattingExtension
 
             return builder
                 .Append(file.Name)
+                .ToString();
+        }
+
+        private string GetStyledName(TreeSummary summary)
+        {
+            if (Style.ColoringDisabled)
+                return builder
+                    .Append(summary.Name)
+                    .ToString();
+
+            return builder
+                .Append(FileSystemStyle.Summary)
+                .Append(summary.Name)
+                .Append(Reset)
                 .ToString();
         }
 

--- a/src/PSTree/Nodes/TreeBase.cs
+++ b/src/PSTree/Nodes/TreeBase.cs
@@ -82,11 +82,9 @@ public abstract class TreeBase<TContainer, TBase>(string source, int depth = 0) 
             builder.SetStyledName(current);
             yield return current;
 
-            if (current.Children is not { Count: > 0 } children)
-                continue;
-
-            for (int i = children.Count - 1; i >= 0; i--)
-                stack.Push(children[i]);
+            if (current.Children is { Count: > 0 } children)
+                for (int i = children.Count - 1; i >= 0; i--)
+                    stack.Push(children[i]);
         }
     }
 

--- a/src/PSTree/Nodes/TreeBase.cs
+++ b/src/PSTree/Nodes/TreeBase.cs
@@ -39,16 +39,21 @@ public abstract class TreeBase<TContainer, TBase>(string source, int depth = 0) 
     string ITree.Name { get => Name; }
 
     private bool IsLast()
-        => Container?.Children is { Count: > 0 } children
-#if NET8_0_OR_GREATER
-            && ReferenceEquals(this, children[^1]);
-#else
-            && ReferenceEquals(this, children[children.Count - 1]);
-#endif
+    {
+        if (this is TreeSummary)
+            return true;
 
-    internal IEnumerable<ITree> Render(
-        int maxDepth,
-        IComparer<TBase>? comparer)
+        if (Container?.Children is not { Count: > 0 } children)
+            return true;
+
+#if NET8_0_OR_GREATER
+        return ReferenceEquals(this, children[^1]);
+#else
+        return ReferenceEquals(this, children[children.Count - 1]);
+#endif
+    }
+
+    internal IEnumerable<ITree> Render(int maxDepth)
     {
         RenderingSet set = TreeStyle.Instance.RenderingSet;
         bool[] continues = new bool[maxDepth + 1];
@@ -78,9 +83,6 @@ public abstract class TreeBase<TContainer, TBase>(string source, int depth = 0) 
             if (current.Children is not { Count: > 0 } children)
                 continue;
 
-            if (comparer is not null)
-                children.Sort(comparer);
-
             for (int i = children.Count - 1; i >= 0; i--)
                 stack.Push(children[i]);
         }
@@ -92,24 +94,32 @@ public abstract class TreeBase<TContainer, TBase>(string source, int depth = 0) 
         Children.Add(child);
     }
 
-    internal void PruneNonIncluded()
+    internal void Consolidate(
+        IComparer<TBase>? comparer,
+        int top, bool prune)
     {
         if (Children is not { Count: > 0 } children)
             return;
 
         for (int i = children.Count - 1; i >= 0; i--)
         {
-            if (children[i] is TContainer container)
-            {
-                container.PruneNonIncluded();
+            if (children[i] is not TContainer container)
+                continue;
 
-                if (container.Include) continue;
-                if (container is TreeDirectory dir)
-                    dir.RecursiveDecrement();
+            container.Consolidate(comparer, top, prune);
 
-                children.RemoveAt(i);
-            }
+            if (!prune || container.Include) continue;
+            if (container is TreeDirectory dir)
+                dir.RecursiveDecrement();
+
+            children.RemoveAt(i);
         }
+
+        if (comparer is not null)
+            children.Sort(comparer);
+
+        if (top > 0 && children.Count > top && this is TreeDirectory tree)
+            tree.Truncate(top);
     }
 
     internal void PropagateInclude()

--- a/src/PSTree/Nodes/TreeBase.cs
+++ b/src/PSTree/Nodes/TreeBase.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Text;
+using PSTree.CodeAnalysis;
 using PSTree.Extensions;
 using PSTree.Interfaces;
 using PSTree.Style;
@@ -43,7 +44,10 @@ public abstract class TreeBase<TContainer, TBase>(string source, int depth = 0) 
         if (this is TreeSummary)
             return true;
 
-        return Container?.Children is { Count: > 0 } children &&
+        // Called only when dp > 0, Container cannot be null in that case
+        Poly.Assert(Container is not null);
+
+        return Container.Children is { Count: > 0 } children &&
 #if NET8_0_OR_GREATER
             ReferenceEquals(this, children[^1]);
 #else

--- a/src/PSTree/Nodes/TreeBase.cs
+++ b/src/PSTree/Nodes/TreeBase.cs
@@ -43,13 +43,11 @@ public abstract class TreeBase<TContainer, TBase>(string source, int depth = 0) 
         if (this is TreeSummary)
             return true;
 
-        if (Container?.Children is not { Count: > 0 } children)
-            return true;
-
+        return Container?.Children is { Count: > 0 } children &&
 #if NET8_0_OR_GREATER
-        return ReferenceEquals(this, children[^1]);
+            ReferenceEquals(this, children[^1]);
 #else
-        return ReferenceEquals(this, children[children.Count - 1]);
+            ReferenceEquals(this, children[children.Count - 1]);
 #endif
     }
 

--- a/src/PSTree/Nodes/TreeDirectory.cs
+++ b/src/PSTree/Nodes/TreeDirectory.cs
@@ -54,7 +54,7 @@ public sealed class TreeDirectory : TreeFileSystemInfo<DirectoryInfo>
 
     internal void Truncate(int top)
     {
-        Poly.Assert(Children is not null && Children.Count > top);
+        Poly.Assert(Children is not null);
         int remove = Children.Count - top;
         int dCount = 0, fCount = 0;
         long totalLength = 0;

--- a/src/PSTree/Nodes/TreeDirectory.cs
+++ b/src/PSTree/Nodes/TreeDirectory.cs
@@ -54,7 +54,7 @@ public sealed class TreeDirectory : TreeFileSystemInfo<DirectoryInfo>
 
     internal void Truncate(int top)
     {
-        Poly.Assert(Children is not null && top > Children.Count);
+        Poly.Assert(Children is not null && Children.Count > top);
         int remove = Children.Count - top;
         int dCount = 0, fCount = 0;
         long totalLength = 0;

--- a/src/PSTree/Nodes/TreeDirectory.cs
+++ b/src/PSTree/Nodes/TreeDirectory.cs
@@ -50,4 +50,31 @@ public sealed class TreeDirectory : TreeFileSystemInfo<DirectoryInfo>
             i.TotalItemCount += ItemCount;
         }
     }
+
+    internal void Truncate(int top)
+    {
+        if (Children is not { Count: > 0 } children) return;
+
+        int remove = children.Count - top;
+        int dCount = 0, fCount = 0;
+        long totalLength = 0;
+
+        for (int i = top; i < children.Count; i++)
+        {
+            TreeFileSystemInfo current = children[i];
+
+            if (current.IsContainer) dCount++;
+            else fCount++;
+
+            totalLength += current.Length;
+        }
+
+        TreeSummary summary = new(this, dCount, fCount)
+        {
+            Length = totalLength
+        };
+
+        children.RemoveRange(top, remove);
+        children.Add(summary);
+    }
 }

--- a/src/PSTree/Nodes/TreeDirectory.cs
+++ b/src/PSTree/Nodes/TreeDirectory.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using PSTree.CodeAnalysis;
 
 namespace PSTree.Nodes;
 
@@ -53,15 +54,14 @@ public sealed class TreeDirectory : TreeFileSystemInfo<DirectoryInfo>
 
     internal void Truncate(int top)
     {
-        if (Children is not { Count: > 0 } children) return;
-
-        int remove = children.Count - top;
+        Poly.Assert(Children is not null && top > Children.Count);
+        int remove = Children.Count - top;
         int dCount = 0, fCount = 0;
         long totalLength = 0;
 
-        for (int i = top; i < children.Count; i++)
+        for (int i = top; i < Children.Count; i++)
         {
-            TreeFileSystemInfo current = children[i];
+            TreeFileSystemInfo current = Children[i];
 
             if (current.IsContainer) dCount++;
             else fCount++;
@@ -74,7 +74,7 @@ public sealed class TreeDirectory : TreeFileSystemInfo<DirectoryInfo>
             Length = totalLength
         };
 
-        children.RemoveRange(top, remove);
-        children.Add(summary);
+        Children.RemoveRange(top, remove);
+        Children.Add(summary);
     }
 }

--- a/src/PSTree/Nodes/TreeFileSystemInfo.cs
+++ b/src/PSTree/Nodes/TreeFileSystemInfo.cs
@@ -6,6 +6,8 @@ namespace PSTree.Nodes;
 public abstract class TreeFileSystemInfo(string source, int depth = 0)
     : TreeBase<TreeDirectory, TreeFileSystemInfo>(source, depth), IFileSystemNode
 {
+    public abstract string Mode { get; }
+
     public long Length { get; internal set; }
 
     public string GetFormattedLength()

--- a/src/PSTree/Nodes/TreeFileSystemInfo_T.cs
+++ b/src/PSTree/Nodes/TreeFileSystemInfo_T.cs
@@ -14,7 +14,7 @@ public abstract class TreeFileSystemInfo<T>(T fsinfo, string source, int depth =
 
     public override string Name { get => Instance.Name; }
 
-    public string Mode { get => FileSystemProvider.Mode(InstanceAsPSO); }
+    public override string Mode { get => FileSystemProvider.Mode(InstanceAsPSO); }
 
     public string FullName { get => Instance.FullName; }
 

--- a/src/PSTree/Nodes/TreeRegistryValue.cs
+++ b/src/PSTree/Nodes/TreeRegistryValue.cs
@@ -1,5 +1,6 @@
 #if WINDOWS
 using Microsoft.Win32;
+using PSTree.CodeAnalysis;
 
 namespace PSTree.Nodes;
 
@@ -36,6 +37,10 @@ public sealed class TreeRegistryValue : TreeRegistryBase
     private static string GetNameOrDefault(string name)
         => string.IsNullOrEmpty(name) ? "(Default)" : name;
 
-    public object? GetValue() => Container!.GetValue(_name);
+    public object? GetValue()
+    {
+        Poly.Assert(Container is not null);
+        return Container.GetValue(_name);
+    }
 }
 #endif

--- a/src/PSTree/Nodes/TreeSummary.cs
+++ b/src/PSTree/Nodes/TreeSummary.cs
@@ -8,14 +8,14 @@ public sealed class TreeSummary : TreeFileSystemInfo
 
     internal override bool IsContainer { get; } = false;
 
-    internal TreeSummary(TreeDirectory parent, int dirCount, int fileCount)
+    internal TreeSummary(TreeDirectory parent, int dCount, int fCount)
         : base(parent.Source, parent.Depth + 1)
     {
         Container = parent;
-        Name = GetName(dirCount, fileCount);
+        Name = GetName(dCount, fCount);
     }
 
-    private static string GetName(int dirCount, int fileCount)
+    private static string GetName(int dCount, int fCount)
     {
         const string d = "folder";
         const string f = "file";
@@ -23,11 +23,11 @@ public sealed class TreeSummary : TreeFileSystemInfo
         static string Label(int count, string noun)
             => count == 1 ? $"{count} {noun}" : $"{count} {noun}s";
 
-        return (dirCount, fileCount) switch
+        return (dCount, fCount) switch
         {
-            ( > 0, > 0) => $"[+{Label(dirCount, d)}, +{Label(fileCount, f)}]",
-            ( > 0,   0) => $"[+{Label(dirCount, d)}]",
-            _           => $"[+{Label(fileCount, f)}]"
+            ( > 0, > 0) => $"[+{Label(dCount, d)}, +{Label(fCount, f)}]",
+            ( > 0,   0) => $"[+{Label(dCount, d)}]",
+            _           => $"[+{Label(fCount, f)}]"
         };
     }
 }

--- a/src/PSTree/Nodes/TreeSummary.cs
+++ b/src/PSTree/Nodes/TreeSummary.cs
@@ -1,0 +1,33 @@
+namespace PSTree.Nodes;
+
+public sealed class TreeSummary : TreeFileSystemInfo
+{
+    public override string Mode { get; } = "TBD";
+
+    public override string Name { get; }
+
+    internal override bool IsContainer { get; } = false;
+
+    internal TreeSummary(TreeDirectory parent, int dirCount, int fileCount)
+        : base(parent.Source, parent.Depth + 1)
+    {
+        Container = parent;
+        Name = GetName(dirCount, fileCount);
+    }
+
+    private static string GetName(int dirCount, int fileCount)
+    {
+        const string d = "folder";
+        const string f = "file";
+
+        static string Label(int count, string noun)
+            => count == 1 ? $"{count} {noun}" : $"{count} {noun}s";
+
+        return (dirCount, fileCount) switch
+        {
+            ( > 0, > 0) => $"[+{Label(dirCount, d)}, +{Label(fileCount, f)}]",
+            ( > 0,   0) => $"[+{Label(dirCount, d)}]",
+            _           => $"[+{Label(fileCount, f)}]"
+        };
+    }
+}

--- a/src/PSTree/Nodes/TreeSummary.cs
+++ b/src/PSTree/Nodes/TreeSummary.cs
@@ -2,7 +2,7 @@ namespace PSTree.Nodes;
 
 public sealed class TreeSummary : TreeFileSystemInfo
 {
-    public override string Mode { get; } = "TBD";
+    public override string Mode { get; } = "-----";
 
     public override string Name { get; }
 

--- a/src/PSTree/Style/FileSystemStyle.cs
+++ b/src/PSTree/Style/FileSystemStyle.cs
@@ -38,7 +38,7 @@ public sealed class FileSystemStyle
     {
         get;
         set => field = TreeStyle.ThrowIfInvalidSequence(value);
-    } = "\x1B[97;3m";
+    } = "\x1B[37;3m";
 
     public Extension Extension { get; } = new();
 

--- a/src/PSTree/Style/FileSystemStyle.cs
+++ b/src/PSTree/Style/FileSystemStyle.cs
@@ -34,6 +34,12 @@ public sealed class FileSystemStyle
         set => field = TreeStyle.ThrowIfInvalidSequence(value);
     } = "\x1B[32;1m";
 
+    public string Summary
+    {
+        get;
+        set => field = TreeStyle.ThrowIfInvalidSequence(value);
+    } = "\x1B[97;3m";
+
     public Extension Extension { get; } = new();
 
     internal bool IsExecutable(TreeFile file) => _exec.Contains(file.Extension);

--- a/tests/GetPSTreeCommand.tests.ps1
+++ b/tests/GetPSTreeCommand.tests.ps1
@@ -197,4 +197,21 @@ Describe 'Get-PSTree' {
             Get-PSTree -SortBy $_ -Depth 1 | Should -Not -BeNullOrEmpty
         }
     }
+
+    It 'Supports Top' {
+        Get-PSTree -Top 2 |
+            ForEach-Object GetType |
+            Should -Contain ([PSTree.Nodes.TreeSummary])
+    }
+
+    It 'Supports Top with SortBy DirectoriesFirstBySize' {
+        Get-PSTree -Top 2 -SortBy DirectoriesFirstBySize |
+            ForEach-Object GetType |
+            Should -Contain ([PSTree.Nodes.TreeSummary])
+    }
+
+    It 'Should throw if Top used with incompatible sort mode' {
+        { Get-PSTree -Top 2 -SortBy FilesFirst } |
+            Should -Throw -ExceptionType ([System.InvalidOperationException])
+    }
 }

--- a/tests/TreeStyle.tests.ps1
+++ b/tests/TreeStyle.tests.ps1
@@ -89,6 +89,9 @@ Describe 'FileSystemStyle Type' {
 
         Get-PSTree $TestDrive -Recurse -Include *.ps1, *.exe | ForEach-Object Hierarchy |
             Should -Not -Match '\b\x1B\[(?:[0-9]+;?){1,}m'
+
+        Get-PSTree $TestDrive -Top 2 | ForEach-Object Hierarchy |
+            Should -Not -Match '\b\x1B\[(?:[0-9]+;?){1,}m'
     }
 }
 

--- a/tests/TreeStyle.tests.ps1
+++ b/tests/TreeStyle.tests.ps1
@@ -68,6 +68,12 @@ Describe 'FileSystemStyle Type' {
         { $style.FileSystem.Executable = $style.Palette.Background.BrightGreen } | Should -Not -Throw
     }
 
+    It 'Summary property can be set' {
+        $style.FileSystem.Summary | Should -Not -BeNullOrEmpty
+        { $style.FileSystem.Summary = 'Invalid' } | Should -Throw
+        { $style.FileSystem.Summary = $style.Palette.Background.BrightGreen } | Should -Not -Throw
+    }
+
     It 'OutputRendering defines if output is colored' {
         $style.OutputRendering = [PSTree.Style.OutputRendering]::Host
 

--- a/tests/TreeStyle.tests.ps1
+++ b/tests/TreeStyle.tests.ps1
@@ -75,7 +75,7 @@ Describe 'FileSystemStyle Type' {
     }
 
     It 'OutputRendering defines if output is colored' {
-        $style.OutputRendering = [PSTree.Style.OutputRendering]::Host
+        $style.OutputRendering = 'Host'
 
         Get-PSTree $TestDrive -Recurse -Include *.ps1, *.exe | ForEach-Object {
             if ($_.Extension -eq '.exe' -and $IsLinux) {
@@ -85,13 +85,17 @@ Describe 'FileSystemStyle Type' {
             $_.Hierarchy | Should -Match '\b\x1B\[(?:[0-9]+;?){1,}m'
         }
 
-        $style.OutputRendering = [PSTree.Style.OutputRendering]::PlainText
+        $style.OutputRendering = 'PlainText'
 
         Get-PSTree $TestDrive -Recurse -Include *.ps1, *.exe | ForEach-Object Hierarchy |
             Should -Not -Match '\b\x1B\[(?:[0-9]+;?){1,}m'
 
-        Get-PSTree $TestDrive -Top 2 | ForEach-Object Hierarchy |
-            Should -Not -Match '\b\x1B\[(?:[0-9]+;?){1,}m'
+        Get-PSTree $TestDrive -Top 1 |
+            Where-Object { $_ -is [PSTree.Nodes.TreeSummary] } |
+            ForEach-Object Hierarchy |
+            Should -Not -Match '\b\x1B\['
+
+        $style.OutputRendering = 'Host'
     }
 }
 
@@ -109,15 +113,15 @@ if ($isWin) {
         }
 
         It 'OutputRendering defines if output is colored' {
-            $style.OutputRendering = [PSTree.Style.OutputRendering]::Host
+            $style.OutputRendering = 'Host'
             Get-PSTreeRegistry HKCU:\ -KeysOnly | ForEach-Object Hierarchy |
                 Should -Match '\s?\x1B\[(?:[0-9]+;?){1,}m'
 
-            $style.OutputRendering = [PSTree.Style.OutputRendering]::PlainText
+            $style.OutputRendering = 'PlainText'
             Get-PSTreeRegistry HKCU:\ | ForEach-Object Hierarchy |
                 Should -Not -Match '\s?\x1B\[(?:[0-9]+;?){1,}m'
 
-            $style.OutputRendering = [PSTree.Style.OutputRendering]::Host
+            $style.OutputRendering = 'Host'
         }
     }
 
@@ -173,7 +177,7 @@ if ($isWin) {
         }
 
         It 'Adds coloring to TreeRegistryValue instances' {
-            $style.OutputRendering = [PSTree.Style.OutputRendering]::Host
+            $style.OutputRendering = 'Host'
 
             Get-PSTreeRegistry HKCU:\ -EA 0 |
                 Where-Object Kind -In DWord, ExpandString, String |


### PR DESCRIPTION
### New Features

- Added `-Top` parameter (alias `-t`) to `Get-PSTree` to limit the number of children displayed per directory.
    - Using `-Top` automatically enables `-RecursiveSize` and defaults `-SortBy` to `Size` when `-SortBy` is not bound.
    - Added validation logic to ensure `-Top` is only used with size-based sort modes (`Size` or `DirectoriesFirstBySize`), throwing a terminating error for incompatible combinations. 
- New `TreeSummary` node class to represent aggregated "overflow" items when `-Top` is used.
- Added `SummaryStyle` property to `TreeStyle.FileSystemStyle` to allow customizable coloring for summary objects.

### Changed

- Refactored tree processing to separate Data Shaping (sorting, pruning, and truncation) from `.Render()`, improving consistency and performance during enumeration.
- Updated and expanded documentation for `Get-PSTree` (especially the `-Top` parameter, `TreeSummary` output type, and usage examples).

