### PR TITLE
Fix non-streaming output caused by `WriteObject(..., enumerateCollection: true)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG
 
+## v3.0.1
+
+### Fixed
+
+- Fixed non-streaming output caused by `WriteObject(..., enumerateCollection: true)`.
+- `TreeBase.Render()` now accepts `PSCmdlet` as a parameter and writes objects directly, enabling proper PowerShell streaming behavior.
+- Simplified `RegistryMappings` API (`TryGetKey` → `Get`) since only the five standard registry hives are supported.
+- Improved `TryGetKey` logic in `GetPSTreeRegistryCommand` for better readability and error handling.
+
+### Changed
+
+- Minor internal cleanups and code style improvements.
+
 ## v3.0.0
 
 ### Major Changes

--- a/module/PSTree.psd1
+++ b/module/PSTree.psd1
@@ -16,7 +16,7 @@
     }
 
     # Version number of this module.
-    ModuleVersion = '3.0.0'
+    ModuleVersion = '3.0.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/PSTree/Commands/GetPSTreeRegistryCommand.cs
+++ b/src/PSTree/Commands/GetPSTreeRegistryCommand.cs
@@ -86,30 +86,25 @@ public sealed class GetPSTreeRegistryCommand
         (string baseKey, string? subKey) = path.Split(['\\'], 2);
         key = default;
 
-        if (!RegistryMappings.TryGetKey(baseKey, out RegistryKey? value))
-            return false;
-
-        if (!string.IsNullOrWhiteSpace(subKey))
+        try
         {
-            try
+            if (RegistryMappings.TryGetKey(baseKey, out key))
             {
-                if ((key = value.OpenSubKey(subKey)) is null)
-                {
-                    this.WriteInvalidPathError(path);
-                    return false;
-                }
-            }
-            catch (SecurityException exception)
-            {
-                WriteError(exception.ToSecurityError(path));
-                return false;
-            }
+                if (string.IsNullOrWhiteSpace(subKey))
+                    return true;
 
-            return true;
+                key = key.OpenSubKey(subKey);
+                if (key is not null) return true;
+
+                this.WriteInvalidPathError(path);
+            }
+        }
+        catch (SecurityException exception)
+        {
+            WriteError(exception.ToSecurityError(path));
         }
 
-        key = value;
-        return true;
+        return false;
     }
 
     protected override IComparer<TreeRegistryBase>? GetComparer()

--- a/src/PSTree/Commands/GetPSTreeRegistryCommand.cs
+++ b/src/PSTree/Commands/GetPSTreeRegistryCommand.cs
@@ -84,24 +84,19 @@ public sealed class GetPSTreeRegistryCommand
     private bool TryGetKey(string path, [NotNullWhen(true)] out RegistryKey? key)
     {
         (string baseKey, string? subKey) = path.Split(['\\'], 2);
-        key = default;
+        key = RegistryMappings.Get(baseKey);
+        if (string.IsNullOrWhiteSpace(subKey)) return true;
 
         try
         {
-            if (RegistryMappings.TryGetKey(baseKey, out key))
-            {
-                if (string.IsNullOrWhiteSpace(subKey))
-                    return true;
-
-                key = key.OpenSubKey(subKey);
-                if (key is not null) return true;
-
-                this.WriteInvalidPathError(path);
-            }
+            key = key.OpenSubKey(subKey);
+            if (key is not null) return true;
+            this.WriteInvalidPathError(path);
         }
         catch (SecurityException exception)
         {
             WriteError(exception.ToSecurityError(path));
+            key = null;
         }
 
         return false;

--- a/src/PSTree/Commands/TreeCommandBase.cs
+++ b/src/PSTree/Commands/TreeCommandBase.cs
@@ -152,10 +152,7 @@ public abstract class TreeCommandBase<TContainer, TBase, TSort> : PSCmdlet
         }
 
         container.Consolidate(_comparer, Top, HasInclude);
-
-        WriteObject(
-            container.Render(maxdp),
-            enumerateCollection: true);
+        container.Render(this, maxdp);
     }
 
     protected abstract void BuildOne(TContainer current, int depth);

--- a/src/PSTree/Internal/_FormattingInternals.cs
+++ b/src/PSTree/Internal/_FormattingInternals.cs
@@ -24,7 +24,7 @@ public static class _FormattingInternals
     ];
 
     [Hidden, EditorBrowsable(EditorBrowsableState.Never)]
-    public static string GetSource(ITree item) => item.Source;
+    public static string GetSource(ITree item) => item.Source.Replace(@"D:\Zen\Documents\Scripts", "..");
 
     [Hidden, EditorBrowsable(EditorBrowsableState.Never)]
     public static string GetFormattedLength(long length)

--- a/src/PSTree/Internal/_FormattingInternals.cs
+++ b/src/PSTree/Internal/_FormattingInternals.cs
@@ -24,7 +24,7 @@ public static class _FormattingInternals
     ];
 
     [Hidden, EditorBrowsable(EditorBrowsableState.Never)]
-    public static string GetSource(ITree item) => item.Source.Replace(@"D:\Zen\Documents\Scripts", "..");
+    public static string GetSource(ITree item) => item.Source;
 
     [Hidden, EditorBrowsable(EditorBrowsableState.Never)]
     public static string GetFormattedLength(long length)

--- a/src/PSTree/Nodes/TreeBase.cs
+++ b/src/PSTree/Nodes/TreeBase.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+using System.Management.Automation;
 using System.Text;
+using System.Threading;
 using PSTree.CodeAnalysis;
 using PSTree.Extensions;
 using PSTree.Interfaces;
@@ -55,7 +57,7 @@ public abstract class TreeBase<TContainer, TBase>(string source, int depth = 0) 
 #endif
     }
 
-    internal IEnumerable<ITree> Render(int maxDepth)
+    internal void Render(PSCmdlet cmdlet, int maxDepth)
     {
         RenderingSet set = TreeStyle.Instance.RenderingSet;
         bool[] continues = new bool[maxDepth + 1];
@@ -80,7 +82,7 @@ public abstract class TreeBase<TContainer, TBase>(string source, int depth = 0) 
             }
 
             builder.SetStyledName(current);
-            yield return current;
+            cmdlet.WriteObject(current);
 
             if (current.Children is { Count: > 0 } children)
                 for (int i = children.Count - 1; i >= 0; i--)

--- a/src/PSTree/Registry/RegistryMappings.cs
+++ b/src/PSTree/Registry/RegistryMappings.cs
@@ -18,7 +18,6 @@ internal static class RegistryMappings
         ["HKEY_CURRENT_CONFIG"] = Win32Registry.CurrentConfig
     };
 
-    internal static bool TryGetKey(string key, [NotNullWhen(true)] out RegistryKey? value)
-        => s_map.TryGetValue(key, out value);
+    internal static RegistryKey Get(string key) => s_map[key];
 }
 #endif

--- a/tests/GetPSTreeRegistryCommand.tests.ps1
+++ b/tests/GetPSTreeRegistryCommand.tests.ps1
@@ -55,7 +55,7 @@ Describe 'Get-PSTreeRegistry.Windows' {
             { Get-PSTreeRegistry -Path HKLM:\ } |
                 Should -Throw -ExceptionType ([SecurityException])
 
-            { Get-PSTreeRegistry HKLM:\SECURITY } |
+            { Get-PSTreeRegistry -LiteralPath HKLM:\SECURITY } |
                 Should -Throw -ExceptionType ([SecurityException])
         }
 


### PR DESCRIPTION
# v3.0.1

## Fixed

- Fixed non-streaming output caused by `WriteObject(..., enumerateCollection: true)`.
- `TreeBase.Render()` now accepts `PSCmdlet` as a parameter and writes objects directly, enabling proper PowerShell streaming behavior.
- Simplified `RegistryMappings` API (`TryGetKey` → `Get`) since only the five standard registry hives are supported.
- Improved `TryGetKey` logic in `GetPSTreeRegistryCommand` for better readability and error handling.

## Changed

- Minor internal cleanups and code style improvements.